### PR TITLE
Support toolchain path specification

### DIFF
--- a/tests/test-default-run/sources/CMakeLists.txt
+++ b/tests/test-default-run/sources/CMakeLists.txt
@@ -9,4 +9,4 @@ project(main LANGUAGES C CXX)
 add_executable(main ${CMAKE_SOURCE_DIR}/main.cpp)
 target_compile_options(main PRIVATE "-std=c++20")
 
-add_test(NAME test-main COMMAND main)
+add_test(NAME test-default-run COMMAND main)

--- a/tests/test-source-option/CMakeLists.txt
+++ b/tests/test-source-option/CMakeLists.txt
@@ -9,4 +9,5 @@ project(main LANGUAGES C CXX)
 add_executable(main ${CMAKE_SOURCE_DIR}/main.cpp)
 target_compile_options(main PRIVATE "-std=c++20")
 
-add_test(NAME test-main COMMAND main)
+add_test(NAME test-source-option COMMAND main)
+

--- a/tests/test-toolchain-option/run.sh
+++ b/tests/test-toolchain-option/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+./mk --test --cleanup --toolchain sources/Test-toolchain.cmake
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
+
+rm -rf ./build-*
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi

--- a/tests/test-toolchain-option/sources/CMakeLists.txt
+++ b/tests/test-toolchain-option/sources/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20)
+
+option(VERBOSE "Verbose mode flag" OFF)
+
+enable_testing()
+
+project(test_toolchain_option LANGUAGES CXX)
+
+add_executable(main ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+
+if (WITH_TOOLCHAIN)
+    target_compile_definitions(main PRIVATE WITH_TOOLCHAIN)
+endif()
+
+target_compile_options(main PRIVATE "-std=c++20")
+
+add_test(NAME test-toolchain-option COMMAND main)
+

--- a/tests/test-toolchain-option/sources/Test-toolchain.cmake
+++ b/tests/test-toolchain-option/sources/Test-toolchain.cmake
@@ -1,0 +1,1 @@
+set(WITH_TOOLCHAIN ON)

--- a/tests/test-toolchain-option/sources/main.cpp
+++ b/tests/test-toolchain-option/sources/main.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+int main() {
+#if defined(WITH_TOOLCHAIN)
+    std::cout << "OK!" << std::endl;
+    return 0;
+#else
+    std::cout << "NOT OK!" << std::endl;
+    return 1;
+#endif
+}


### PR DESCRIPTION
closes #2

- Add 'toolchain' option which allows specification of the CMake toolchain file